### PR TITLE
Force destroy in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ build: guard-STACK
 
 
 destroy: guard-STACK
-	stacker destroy --region ${AWS_DEFAULT_REGION} ${ARGS} conf/$(STACK).env stacker.yaml
+	stacker destroy --force --region ${AWS_DEFAULT_REGION} ${ARGS} conf/$(STACK).env stacker.yaml
 .PHONY: destroy


### PR DESCRIPTION
Why:

* as it stands, destroy doesn't actually do anything

This change addresses the need by:

* update destroy command in makefile to use the --force flag

Are there any side effects?

* resources in aws will be killed ded